### PR TITLE
Min replicas extra manifests

### DIFF
--- a/src/helm/azure-pipelines-agent/templates/NOTES.txt
+++ b/src/helm/azure-pipelines-agent/templates/NOTES.txt
@@ -1,5 +1,9 @@
 {{- if (.Values.secret.create) -}}
 Check your Azure DevOps portal at to manage the Azure Pipelines Agent ({{ .Values.pipelines.organizationURL | quote | required "A value for .Values.pipelines.organizationURL is required" }}/_settings/agentpools).
+{{- else -}}
+Secret creation disabled, remember to create/update the secret {{ include "azure-pipelines-agent.secretName" . | quote }} and that the fields personalAccessToken and organizationURL are required
+{{- end -}}
+Check your Azure DevOps portal at to manage the Azure Pipelines Agent ({{ .Values.pipelines.organizationURL | quote | required "A value for .Values.pipelines.organizationURL is required" }}/_settings/agentpools).
 {{- end -}}
 
 {{- if and (.Values.autoscaling.enabled) (.Capabilities.APIVersions.Has "keda.sh/v1alpha1") -}}

--- a/src/helm/azure-pipelines-agent/templates/NOTES.txt
+++ b/src/helm/azure-pipelines-agent/templates/NOTES.txt
@@ -1,4 +1,6 @@
+{{- if (.Values.secret.create) -}}
 Check your Azure DevOps portal at to manage the Azure Pipelines Agent ({{ .Values.pipelines.organizationURL | quote | required "A value for .Values.pipelines.organizationURL is required" }}/_settings/agentpools).
+{{- end -}}
 
 {{- if and (.Values.autoscaling.enabled) (.Capabilities.APIVersions.Has "keda.sh/v1alpha1") -}}
 Your cluster is KEDA enabled, your pipelines agents will scale based on your usage. When you won't use them, they will be automatically removed.

--- a/src/helm/azure-pipelines-agent/templates/extraManifests.yaml
+++ b/src/helm/azure-pipelines-agent/templates/extraManifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/src/helm/azure-pipelines-agent/templates/extraManifests.yaml
+++ b/src/helm/azure-pipelines-agent/templates/extraManifests.yaml
@@ -1,4 +1,4 @@
 {{ range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{- toYaml . }}
 {{ end }}

--- a/src/helm/azure-pipelines-agent/templates/hpa.yaml
+++ b/src/helm/azure-pipelines-agent/templates/hpa.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   failedJobsHistoryLimit: {{ .Values.pipelines.cleanup.failed | int | required "A value for .Values.pipelines.cleanup.failed is required" }}
   maxReplicaCount: {{ .Values.autoscaling.maxReplicas | int | required "A value for .Values.autoscaling.maxReplicas is required" }}
-  minReplicaCount: 0
+  minReplicaCount: {{ .Values.autoscaling.minReplicas | int | required "A value for .Values.autoscaling.minReplicas is required" }}
   pollingInterval: 15
   successfulJobsHistoryLimit: {{ .Values.pipelines.cleanup.successful | int | required "A value for .Values.pipelines.cleanup.successful is required" }}
   jobTargetRef:

--- a/src/helm/azure-pipelines-agent/values.yaml
+++ b/src/helm/azure-pipelines-agent/values.yaml
@@ -13,6 +13,7 @@ replicaCount: 3
 
 autoscaling:
   enabled: true
+  minReplicas: 0
   maxReplicas: 100 # Arbitrary value to avoid misconfiguration; can be enlarged if needed
 
 pipelines:

--- a/src/helm/azure-pipelines-agent/values.yaml
+++ b/src/helm/azure-pipelines-agent/values.yaml
@@ -131,3 +131,15 @@ extraVolumeMounts: []
 #     image: busybox
 #     command: ["/bin/sh", "-c", "echo Hello World"]
 initContainers: []
+
+## Extra manifests to deploy as an array
+extraManifests: []
+
+  # - apiVersion: v1
+  #   kind: Secret
+  #   metadata:
+  #   labels:
+  #     name: azure-pipeline-secret
+  #   data:
+  #     personalAccessToken: "value"
+  #     organizationURL: "value"


### PR DESCRIPTION
Hi,

This PR adds the following features:

* The possibility to set the number of `minReplicaCount` on the `ScaleJob` definition to an arbitrary value instead of having it hard coded.
* To pass extra manifests to be created by the chart
* Turns `organizationURL` only mandatory if you set the chart to create the required secret